### PR TITLE
Fix typo in config.yaml

### DIFF
--- a/src/test/resources/com/aws/greengrass/lifecyclemanager/config.yaml
+++ b/src/test/resources/com/aws/greengrass/lifecyclemanager/config.yaml
@@ -56,7 +56,7 @@ services:
       shutdown: (docker stop nginx; docker rm nginx; exit 0)2>&1
   monitoring:
     Lifecycle:
-      install: echo "install monibering"
+      install: echo "install monitoring"
     Dependencies:
       - greenlake
 


### PR DESCRIPTION
Just a typo: monibering -> monitoring

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
